### PR TITLE
use PEP 735 for dev-dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ dependencies = [
     "psycopg[binary]>=3.2.3",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "plain-dev",
     "plain-pytest",
 ]


### PR DESCRIPTION
move to new standard for dev-dependency
reference, https://peps.python.org/pep-0735/
uv already support this